### PR TITLE
Changed the way how the BytecodeManager depends on the JavaSpecificat…

### DIFF
--- a/artificer/src/test/java/net/technolords/tools/artificer/analyser/dotclass/BytecodeParserTest.java
+++ b/artificer/src/test/java/net/technolords/tools/artificer/analyser/dotclass/BytecodeParserTest.java
@@ -14,6 +14,7 @@ import org.testng.annotations.Test;
 
 import junit.framework.Assert;
 import net.technolords.tools.artificer.TestSupport;
+import net.technolords.tools.artificer.domain.meta.Meta;
 import net.technolords.tools.artificer.domain.resource.Resource;
 import net.technolords.tools.data.field.FieldTestWithAnnotations;
 import net.technolords.tools.data.field.FieldTestWithConstants;
@@ -33,7 +34,6 @@ import net.technolords.tools.data.method.MethodTestWithStaticMethods;
  */
 public class BytecodeParserTest extends TestSupport {
     private static final Logger LOGGER = LoggerFactory.getLogger(BytecodeParserTest.class);
-    private static final String KNOWN_JAVA_SPECIFICATIONS_REFERENCE_FILE = "analyser/dotclass/java-specifications.xml";
     private static final String JAVA_8 = "1.8";
 
     /**
@@ -139,8 +139,8 @@ public class BytecodeParserTest extends TestSupport {
         resource.setPath(pathToDataSample);
         resource.setName(className.getSimpleName());
         resource.setCompiledVersion(compiledVersion);
-        BytecodeParser bytecodeParser = new BytecodeParser(KNOWN_JAVA_SPECIFICATIONS_REFERENCE_FILE);
-        bytecodeParser.analyseBytecode(resource);
+        BytecodeParser bytecodeParser = new BytecodeParser();
+        bytecodeParser.analyseBytecode(new Meta(), resource);
 
         // Test result of analysis
         Assert.assertEquals("Expected total referenced classes to be equal", expectedReferencedClasses.size(), resource.getReferencedClasses().size());
@@ -255,8 +255,8 @@ public class BytecodeParserTest extends TestSupport {
         resource.setName(className.getSimpleName());
         resource.setCompiledVersion(compiledVersion);
 
-        BytecodeParser bytecodeParser = new BytecodeParser(KNOWN_JAVA_SPECIFICATIONS_REFERENCE_FILE);
-        bytecodeParser.analyseBytecode(resource);
+        BytecodeParser bytecodeParser = new BytecodeParser();
+        bytecodeParser.analyseBytecode(new Meta(), resource);
 
         // Test result of analysis
         Assert.assertEquals("Expected total referenced classes to be equal", expectedReferencedClasses.size(), resource.getReferencedClasses().size());

--- a/artificer/src/test/java/net/technolords/tools/artificer/analyser/dotclass/ConstantPoolAnalyserTest.java
+++ b/artificer/src/test/java/net/technolords/tools/artificer/analyser/dotclass/ConstantPoolAnalyserTest.java
@@ -14,6 +14,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import net.technolords.tools.artificer.TestSupport;
+import net.technolords.tools.artificer.domain.meta.Meta;
 import net.technolords.tools.artificer.domain.resource.Resource;
 
 /**
@@ -36,6 +37,7 @@ public class ConstantPoolAnalyserTest extends TestSupport {
             { "abc.class",       false, new HashSet<>()                 }
         };
     }
+
     @Test(dataProvider = "dataSetClasses")
     public void testReferencedClassesExtraction(final String classname, final boolean validClass, final Set<String> expectedRefClasses) {
         Path pathToResourceLocation = FileSystems.getDefault().getPath(super.getPathToClassFolder().toAbsolutePath() + File.separator + classname);
@@ -47,8 +49,8 @@ public class ConstantPoolAnalyserTest extends TestSupport {
         resource.setCompiledVersion("1.8");
         resource.setValidClass(validClass);
         // Analyse bytecode
-        BytecodeParser bytecodeParser = new BytecodeParser(KNOWN_JAVA_SPECIFICATIONS_REFERENCE_FILE);
-        bytecodeParser.analyseBytecode(resource);
+        BytecodeParser bytecodeParser = new BytecodeParser();
+        bytecodeParser.analyseBytecode(new Meta(), resource);
         // Analyse constant pool
         // TODO: update the test and assert on the 5 referenced classes, rather than the current 3 (See also BytecodeParserTest)
         Set<String> referencedClasses = ConstantPoolAnalyser.extractReferencedClasses(resource.getConstantPool());


### PR DESCRIPTION
…ionManager, as it now is 'behind' the BytecodeManager rather then present in the ArtifactManager. So basically it is moved deeper and as result the xml file describing the spec is parsed once and re-used.